### PR TITLE
Split App into App and NewApp

### DIFF
--- a/app.go
+++ b/app.go
@@ -1,8 +1,33 @@
 package control
 
+// A struct representing the settable fields of an Ably application.
+type NewApp struct {
+	// The application ID.
+	ID string `json:"id,omitempty"`
+	// The application name.
+	Name string `json:"name,omitempty"`
+	// The application status. Disabled applications will not accept
+	// new connections and will return an error to all clients.
+	Status string `json:"status,omitempty"`
+	// Enforce TLS for all connections. This setting overrides any channel setting.
+	TLSOnly bool `json:"tlsOnly"`
+	// The Firebase Cloud Messaging key.
+	FcmKey string `json:"fcmKey"`
+	// The Apple Push Notification service certificate.
+	// This field can only be used to set a new value,
+	// it will not be populated by queries.
+	ApnsCertificate string `json:"apnsCertificate"`
+	// The Apple Push Notification service private key.
+	// This field can only be used to set a new value,
+	// it will not be populated by queries.
+	ApnsPrivateKey string `json:"apnsPrivateKey"`
+	// The Apple Push Notification service sandbox endpoint.
+	ApnsUseSandboxEndpoint bool `json:"apnsUseSandboxEndpoint"`
+}
+
 // A struct representing an Ably application.
 type App struct {
-	//The application ID.
+	// The application ID.
 	ID string `json:"id,omitempty"`
 	// The ID of your Ably account.
 	AccountID string `json:"accountId,omitempty"`
@@ -35,14 +60,14 @@ func (c *Client) Apps() ([]App, error) {
 }
 
 // CreateApp creates a new Ably app.
-func (c *Client) CreateApp(app *App) (App, error) {
+func (c *Client) CreateApp(app *NewApp) (App, error) {
 	var out App
 	err := c.request("POST", "/accounts/"+c.accountID+"/apps", app, &out)
 	return out, err
 }
 
 // UpdateApp updates an existing Ably app.
-func (c *Client) UpdateApp(id string, app *App) (App, error) {
+func (c *Client) UpdateApp(id string, app *NewApp) (App, error) {
 	var out App
 	err := c.request("PATCH", "/apps/"+id, app, &out)
 	return out, err

--- a/app_test.go
+++ b/app_test.go
@@ -14,10 +14,10 @@ func TestApp(t *testing.T) {
 
 	assert.NotEqual(t, len(apps), 0)
 
-	a, err := client.UpdateApp(app.ID, &App{TLSOnly: false})
+	a, err := client.UpdateApp(app.ID, &NewApp{TLSOnly: false})
 	assert.NoError(t, err)
 	assert.False(t, a.TLSOnly)
-	newApp := App{
+	newApp := NewApp{
 		Status:                 "disabled",
 		TLSOnly:                true,
 		ApnsUseSandboxEndpoint: true,

--- a/client_test.go
+++ b/client_test.go
@@ -42,7 +42,7 @@ func newTestApp(t *testing.T, client *Client) App {
 	n := rand.Uint64()
 	name := "test-" + fmt.Sprint(n)
 	t.Logf("creating app with name: %s", name)
-	app := App{
+	app := NewApp{
 		Name:   name,
 		Status: "enabled",
 		//TLSOnly:                false,
@@ -51,12 +51,12 @@ func newTestApp(t *testing.T, client *Client) App {
 		ApnsPrivateKey:         "",
 		ApnsUseSandboxEndpoint: false,
 	}
-	app, err := client.CreateApp(&app)
+	app_ret, err := client.CreateApp(&app)
 
 	assert.NoError(t, err)
 	apps = append(apps, app.ID)
 
-	return app
+	return app_ret
 }
 
 func newTestClient(t *testing.T) (Client, Me) {


### PR DESCRIPTION
the control API rejects structs with account_id set so we need a struct without it.