### PR TITLE
Set the Ably-Agent HTTP header

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,6 @@ This library uses [semantic versioning](http://semver.org/). For each release, t
 4. Set the `VERSION` constant in `version.go` to the new version number and add this to the git index
 5. Create a PR for the release branch
 6. Once the PR is approved, merge it into `main`
-7. Run `git tag <VERSION_NUMBER>` with the new version and push the tag to git
+7. Add a tag and push to origin - e.g.: `git tag v1.2.3` && `git push origin v1.2.3`
 8. Create the release on Github, from the new tag, including populating the release notes
 9. Update the [Ably Changelog](https://changelog.ably.com/) (via [headwayapp](https://headwayapp.co/)) with these changes (again, you can just copy the notes you added to the CHANGELOG)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ This library uses [semantic versioning](http://semver.org/). For each release, t
 1. Make sure the tests are passing in CI for the branch you're building
 2. Create a new branch for the release, for example `release/1.2.3`
 3. Update the CHANGELOG.md with any customer-affecting changes since the last release and add this to the git index
-4. Replace all references of the current version number with the new version number and add this to the git index
+4. Set the `VERSION` constant in `version.go` to the new version number and add this to the git index
 5. Create a PR for the release branch
 6. Once the PR is approved, merge it into `main`
 7. Run `git tag <VERSION_NUMBER>` with the new version and push the tag to git

--- a/version.go
+++ b/version.go
@@ -1,0 +1,4 @@
+package control
+
+// VERSION is the version of this package.
+const VERSION = "0.1.0"

--- a/version.go
+++ b/version.go
@@ -1,4 +1,6 @@
 package control
 
 // VERSION is the version of this package.
+//
+// It is sent in requests to the Control API in the Ably-Agent HTTP header.
 const VERSION = "0.1.0"


### PR DESCRIPTION
This updates the Client to set the `Ably-Agent` HTTP header.

By default, it sets the header to `ably-control-go/VERSION`, but extra agents can be added by calling the `Client.AddAblyAgent` method.