### PR TITLE
[SDK-3336] - `exchange` Parameter for `AmqpExternalTarget` struct

### DIFF
--- a/rules.go
+++ b/rules.go
@@ -417,6 +417,10 @@ type AmqpExternalTarget struct {
 	// physical queue. See this Ably knowledge base article for details.
 	// https://knowledge.ably.com/what-is-the-format-of-the-routingkey-for-an-amqp-or-kinesis-reactor-rule
 	RoutingKey string `json:"routingKey,omitempty"`
+	// The RabbitMQ exchange, if needed supports interpolation;
+	// see https://faqs.ably.com/what-is-the-format-of-the-routingkey-for-an-amqp-or-kinesis-reactor-rule
+	// for more info. If you don't use RabbitMQ exchanges, leave this blank.
+	Exchange string `json:"exchange,omitempty"`
 	// Reject delivery of the message if the route does not exist, otherwise fail silently.
 	MandatoryRoute bool `json:"mandatoryRoute"`
 	// Marks the message as persistent, instructing the broker to write it to disk if it is in a durable queue.

--- a/rules_test.go
+++ b/rules_test.go
@@ -45,6 +45,7 @@ func TestRuleAmqpExtrernal(t *testing.T) {
 	target := &AmqpExternalTarget{
 		Url:                "amqps://test.com",
 		RoutingKey:         "key",
+		Exchange:           "exchange",
 		MandatoryRoute:     true,
 		PersistentMessages: true,
 		MessageTTL:         50,


### PR DESCRIPTION
Add the `exchange` parameter to the `AmqpExternalTarget` struct. This has been implemented in the Control API and will be exposed in the Ably Terraform provider.

Infra ticket is [INF-3251]

[INF-3251]: https://ably.atlassian.net/browse/INF-3251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ