### PR TITLE
[INF-3250] - Add Token Revocation parameter for Ably Keys

### DIFF
--- a/keys.go
+++ b/keys.go
@@ -19,6 +19,9 @@ type Key struct {
 	Created int `json:"created"`
 	// Unix timestamp representing the date and time of the last modification of the key.
 	Modified int `json:"modified"`
+	// Token revocation is a security mechanism allowing an app to invalidate authentication tokens,
+	// primarily used against malicious clients. Implementation sets tokens' maximum time-to-live (TTL) to one hour.
+	RevocableTokens bool `json:"revocableTokens"`
 }
 
 // A struct representing the settable fields of an Ably key.
@@ -28,6 +31,9 @@ type NewKey struct {
 	// The capabilities that this key has. More information on capabilities
 	// can be found in the Ably documentation https://ably.com/documentation/core-features/authentication#capabilities-explained.
 	Capability map[string][]string `json:"capability"`
+	// Enable Revocable Tokens. More information on Token Revocation can be
+	// found in the Ably documentation https://ably.com/docs/auth/revocation
+	RevocableTokens bool `json:"revocableTokens"`
 }
 
 // Keys lists the API keys associated with the application ID.

--- a/keys_test.go
+++ b/keys_test.go
@@ -15,8 +15,9 @@ func TestKeys(t *testing.T) {
 	name := "test-key-" + fmt.Sprint(rand.Uint64())
 
 	key := NewKey{
-		Name:       name,
-		Capability: map[string][]string{"a": {"subscribe"}},
+		Name:            name,
+		Capability:      map[string][]string{"a": {"subscribe"}},
+		RevocableTokens: true,
 	}
 
 	k, err := client.CreateKey(app.ID, &key)
@@ -24,6 +25,7 @@ func TestKeys(t *testing.T) {
 	assert.Equal(t, key.Name, k.Name)
 	assert.Equal(t, key.Capability, k.Capability)
 	assert.Equal(t, k.Status, 0)
+	assert.Equal(t, key.RevocableTokens, k.RevocableTokens)
 	assert.NotEmpty(t, k.AppID)
 	assert.NotEmpty(t, k.Created)
 	assert.NotEmpty(t, k.Modified)
@@ -35,14 +37,16 @@ func TestKeys(t *testing.T) {
 	assert.NotEmpty(t, keys)
 
 	key = NewKey{
-		Name:       name + "-changed",
-		Capability: map[string][]string{"b": {"publish"}},
+		Name:            name + "-changed",
+		Capability:      map[string][]string{"b": {"publish"}},
+		RevocableTokens: false,
 	}
 
 	k, err = client.UpdateKey(app.ID, k.ID, &key)
 	assert.NoError(t, err)
 	assert.Equal(t, key.Name, k.Name)
 	assert.Equal(t, key.Capability, k.Capability)
+	assert.Equal(t, key.RevocableTokens, k.RevocableTokens)
 
 	err = client.RevokeKey(app.ID, k.ID)
 	assert.NoError(t, err)


### PR DESCRIPTION
Ably keys support token revocation. This commit updates the ably-control-go SDK to allow configuring token revocation for Ably Keys.

Ably key tests have also been updated with the Token revocation parameter.

More information on Token Revocation can be found in the [Ably documentation](https://ably.com/docs/auth/revocation)