### PR TITLE
[INF-4937] Add server-side batching

### DIFF
--- a/namespaces.go
+++ b/namespaces.go
@@ -27,6 +27,14 @@ type Namespace struct {
 	// If true, messages received on a channel will contain a unique timeserial that can be
 	// referenced by later messages for use with message interactions.
 	ExposeTimeserial bool `json:"exposeTimeserial"`
+	// If true, channels within this namespace will start batching inbound
+	// messages instead of sending them out immediately to subscribers as per
+	// the configured policy.
+	BatchingEnabled bool `json:"batchingEnabled"`
+	// When configured, sets the policy for message batching.
+	BatchingPolicy string `json:"batchingPolicy"`
+	// When configured, sets the maximium batching interval in the channel.
+	BatchingInterval *int `json:"batchingInterval,omitempty"`
 }
 
 // Namespaces lists the namespaces for the specified application ID.
@@ -58,4 +66,8 @@ func (c *Client) UpdateNamespace(appID string, namespace *Namespace) (Namespace,
 func (c *Client) DeleteNamespace(appID, namespaceID string) error {
 	err := c.request("DELETE", "/apps/"+appID+"/namespaces/"+namespaceID, nil, nil)
 	return err
+}
+
+func BatchingInterval(interval int) *int {
+	return &interval
 }

--- a/namespaces_test.go
+++ b/namespaces_test.go
@@ -40,6 +40,9 @@ func TestNamespaces(t *testing.T) {
 		PushEnabled:      true,
 		TlsOnly:          true,
 		ExposeTimeserial: true,
+		BatchingEnabled:  true,
+		BatchingPolicy:   "some-policy",
+		BatchingInterval: BatchingInterval(100),
 	}
 
 	n, err = client.UpdateNamespace(app.ID, &namespace)


### PR DESCRIPTION
This implements server-side batching[1].

Since the default value of 0 for the interval is not a valid value, and is evaluated even if `BatchingPolicy` is `false`, I've set this value as a pointer and added a helper function to set it.

[1] https://ably.com/docs/channels#server-side-batching