### PR TITLE
[INF-5307] - Update SDK with `ingress/mongodb`  and `ingress-postgres-outbox` Integration Rules

### DIFF
--- a/ingress_rules.go
+++ b/ingress_rules.go
@@ -1,0 +1,198 @@
+package control
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type NewIngressRuleNoJson NewIngressRule
+
+// IngressRule is a struct representing an Ably Ingress rule.
+type IngressRule struct {
+	// The rule ID.
+	ID string `json:"id,omitempty"`
+	// The Ably application ID.
+	AppID string `json:"appId,omitempty"`
+	// API version. Events and the format of their payloads are versioned.
+	// Please see the Events documentation. https://ably.com/documentation/general/events
+	Version string `json:"version,omitempty"`
+	// The status of the rule. Rules can be enabled or disabled.
+	Status string `json:"status,omitempty"`
+	// Unix timestamp representing the date and time of creation of the rule.
+	Created int `json:"created"`
+	// Unix timestamp representing the date and time of last modification of the rule.
+	Modified int `json:"modified"`
+	// The rule target.
+	Target IngressTarget `json:"target"`
+}
+
+// IngressRuleType gets the type of target this rule has.
+func (r *IngressRule) IngressRuleType() string {
+	return r.Target.TargetType()
+}
+
+func (r *IngressRule) UnmarshalJSON(data []byte) error {
+	var raw rawIngressRule
+	err := json.Unmarshal(data, &raw)
+	if err != nil {
+		return err
+	}
+	switch raw.RuleType {
+	case "ingress/mongodb":
+		var t IngressMongoTarget
+		err = json.Unmarshal(raw.Target, &t)
+		r.Target = &t
+	case "ingress-postgres-outbox":
+		var t IngressPostgresOutboxTarget
+		err = json.Unmarshal(raw.Target, &t)
+		r.Target = &t
+	default:
+		return fmt.Errorf("unknown rule type \"%s\"", raw.RuleType)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	r.ID = raw.ID
+	r.AppID = raw.AppID
+	r.Version = raw.Version
+	r.Status = raw.Status
+	r.Created = raw.Created
+	r.Modified = raw.Modified
+
+	return nil
+}
+
+type rawIngressRule struct {
+	ID       string          `json:"id,omitempty"`
+	AppID    string          `json:"appId,omitempty"`
+	Version  string          `json:"version,omitempty"`
+	Status   string          `json:"status,omitempty"`
+	Created  int             `json:"created"`
+	Modified int             `json:"modified"`
+	RuleType string          `json:"ruleType,omitempty"`
+	Target   json.RawMessage `json:"target"`
+}
+
+// IngressRuleType gets the type of target this rule has.
+func (r *NewIngressRule) IngressRuleType() string {
+	return r.Target.TargetType()
+}
+
+type IngressTarget interface {
+	// TargetType returns the kind of target.
+	TargetType() string
+}
+
+type rawNewIngressRule struct {
+	RuleType string `json:"ruleType,omitempty"`
+	*NewIngressRuleNoJson
+}
+
+// NewRule is used to create a new rule.
+type NewIngressRule struct {
+	// The status of the rule. Rules can be enabled or disabled.
+	Status string `json:"status,omitempty"`
+	// The rule target.
+	Target IngressTarget `json:"target"`
+}
+
+func (r *NewIngressRule) MarshalJSON() ([]byte, error) {
+	raw := rawNewIngressRule{
+		RuleType: r.Target.TargetType(), NewIngressRuleNoJson: (*NewIngressRuleNoJson)(r)}
+
+	return json.Marshal(&raw)
+}
+
+// IngressMongoTarget is the type used for MongoDB Ingress rules.
+type IngressMongoTarget struct {
+	// The URL of the MongoDB server.
+	Url string `json:"url,omitempty"`
+	// Watch is the collection to watch.
+	Database string `json:"database,omitempty"`
+	// The collection to watch.
+	Collection string `json:"collection,omitempty"`
+	// The pipeline to use.
+	Pipeline string `json:"pipeline,omitempty"`
+	// FullDocument controls how the full document is sent.
+	FullDocument string `json:"fullDocument,omitempty"`
+	// FullDocumentBeforeChange controls how the full document is sent.
+	FullDocumentBeforeChange string `json:"fullDocumentBeforeChange,omitempty"`
+	// The primary site.
+	PrimarySite string `json:"primarySite,omitempty"`
+}
+
+// IngressMongoTarget implements the Target interface.
+func (s *IngressMongoTarget) TargetType() string {
+	return "ingress/mongodb"
+}
+
+// RuleType gets the type of target this rule has.
+func (r *IngressRule) RuleType() string {
+	return r.Target.TargetType()
+}
+
+type IngressPostgresOutboxTarget struct {
+	// The URL for your Postgres database.
+	Url string `json:"url,omitempty"`
+	// Schema for the outbox table in your database which allows for the
+	// reliable publication of an ordered sequence of change event messages
+	// over Ably.
+	OutboxTableSchema string `json:"outboxTableSchema,omitempty"`
+	// Name for the outbox table.
+	OutboxTableName string `json:"outboxTableName,omitempty"`
+	// Schema for the nodes table in your database to allow for operation as a
+	// cluster to provide fault tolerance.
+	NodesTableSchema string `json:"nodesTableSchema,omitempty"`
+	// Name for the nodes table.
+	NodesTableName string `json:"nodesTableName,omitempty"`
+	// Determines the level of protection provided by the SSL connection.
+	// Options are: prefer, require, verify-ca, verify-full;
+	// default value is prefer.
+	SslMode string `json:"sslMode,omitempty"`
+	// Optional. Specifies the SSL certificate authority (CA) certificates.
+	// Required if SSL mode is verify-ca or verify-full.
+	SslRootCert string `json:"sslRootCert,omitempty"`
+	//The primary data center in which to run the integration rule.
+	PrimarySite string `json:"primarySite,omitempty"`
+}
+
+// IngressPostgresTarget implements the Target interface.
+func (s *IngressPostgresOutboxTarget) TargetType() string {
+	return "ingress-postgres-outbox"
+}
+
+// Creates an Ingress rule for the application with the specified application ID.
+func (c *Client) CreateIngressRule(appID string, rule *NewIngressRule) (IngressRule, error) {
+	var out IngressRule
+	err := c.request("POST", "/apps/"+appID+"/rules", &rule, &out)
+	return out, err
+}
+
+// Lists the rules for the application specified by the application ID.
+func (c *Client) IngressRules(appID string) ([]IngressRule, error) {
+	var rules []IngressRule
+	err := c.request("GET", "/apps/"+appID+"/rules", nil, &rules)
+	return rules, err
+}
+
+// Returns the ingess rule specified by the rule ID, for the application specified by application ID.
+func (c *Client) IngressRule(appID, ruleID string) (IngressRule, error) {
+	var rule IngressRule
+	err := c.request("GET", "/apps/"+appID+"/rules/"+ruleID, nil, &rule)
+	return rule, err
+}
+
+// Updates the rule specified by the rule ID, for the application specified by application ID.
+func (c *Client) UpdateIngressRule(appID, ruleID string, rule *NewIngressRule) (IngressRule, error) {
+	var out IngressRule
+	err := c.request("PATCH", "/apps/"+appID+"/rules/"+ruleID, &rule, &out)
+	return out, err
+}
+
+// Deletes the rule specified by the rule ID, for the application specified by application ID.
+func (c *Client) DeleteIngressRule(appID, ruleID string) error {
+	err := c.request("DELETE", "/apps/"+appID+"/rules/"+ruleID, nil, nil)
+	return err
+}

--- a/ingress_rules_test.go
+++ b/ingress_rules_test.go
@@ -1,0 +1,67 @@
+package control
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRuleIngressMongo(t *testing.T) {
+	target := &IngressMongoTarget{
+		Url:                      "mongodb://coco:nut@coco.io:27017",
+		Database:                 "coconut",
+		Collection:               "coconut",
+		Pipeline:                 `[{"$set": {"_ablyChannel": "myChannel"}}]`,
+		FullDocument:             "off",
+		FullDocumentBeforeChange: "off",
+		PrimarySite:              "us-east-1-A",
+	}
+
+	testIngressRule(t, target)
+}
+
+func TestRuleIngressPostgresOutbox(t *testing.T) {
+	target := &IngressPostgresOutboxTarget{
+		Url:               "postgres://user:password@example.com:5432/your-database-name",
+		OutboxTableSchema: "public",
+		OutboxTableName:   "outbox",
+		NodesTableSchema:  "public",
+		NodesTableName:    "nodes",
+		SslMode:           "prefer",
+		SslRootCert:       "-----BEGIN CERTIFICATE----- MIIFiTCCA3GgAwIBAgIUYO1Lomxzj7VRawWwEFiQht9OLpUwDQYJKoZIhvcNAQEL BQAwTDELMAkGA1UEBhMCVVMxETAPBgNVBAgMCE1pY2hpZ2FuMQ8wDQYDVQQHDAZX ...snip... TOfReTlUQzgpXRW5h3n2LVXbXQhPGcVitb88Cm2R8cxQwgB1VncM8yvmKhREo2tz 7Y+sUx6eIl4dlNl9kVrH1TD3EwwtGsjUNlFSZhg= -----END CERTIFICATE-----",
+		PrimarySite:       "us-east-1-A",
+	}
+
+	testIngressRule(t, target)
+}
+
+func testIngressRule(t *testing.T, target IngressTarget) {
+	client, _ := newTestClient(t)
+	app := newTestApp(t, &client)
+
+	rule := NewIngressRule{
+		Status: "enabled",
+		Target: target,
+	}
+
+	r, err := client.CreateIngressRule(app.ID, &rule)
+	assert.NoError(t, err)
+	assert.Equal(t, rule.Target, r.Target)
+	assert.Equal(t, rule.Target.TargetType(), r.Target.TargetType())
+	assert.NotEmpty(t, r.ID)
+	assert.NotEmpty(t, r.AppID)
+	assert.NotEmpty(t, r.Version)
+	assert.NotEmpty(t, r.Status)
+	assert.NotEmpty(t, r.Created)
+	assert.NotEmpty(t, r.Modified)
+
+	r2, err := client.IngressRule(app.ID, r.ID)
+	assert.NoError(t, err)
+	assert.Equal(t, r, r2)
+
+	err = client.DeleteIngressRule(app.ID, r.ID)
+	assert.NoError(t, err)
+
+	err = client.DeleteApp(app.ID)
+	assert.NoError(t, err)
+}

--- a/namespaces_test.go
+++ b/namespaces_test.go
@@ -22,6 +22,7 @@ func TestNamespaces(t *testing.T) {
 		PushEnabled:      false,
 		TlsOnly:          false,
 		ExposeTimeserial: false,
+		BatchingEnabled:  false,
 	}
 
 	n, err := client.CreateNamespace(app.ID, &namespace)

--- a/rules_test.go
+++ b/rules_test.go
@@ -41,7 +41,7 @@ func TestRuleKafka(t *testing.T) {
 	testRule(t, target)
 }
 
-func TestRuleAmqpExtrernal(t *testing.T) {
+func TestRuleAmqpExternal(t *testing.T) {
 	target := &AmqpExternalTarget{
 		Url:                "amqps://test.com",
 		RoutingKey:         "key",


### PR DESCRIPTION
[INF-5307] - Update SDK with `ingress/mongodb`  and `ingress-postgres-outbox` Integration Rules

We have recently added Integration Rules for MongoDB and Postgres. This exposes them. An update the the Ably Terraform provider will come in a separate step.

Given the difference between Rules & Ingress Rules, I have split them.

I have also renamed test `TestRuleAmqpExtrernal` to `TestRuleAmqpExternal` 

[INF-5307]: https://ably.atlassian.net/browse/INF-5307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ