### PR TITLE
[INF-5307] - Upgrade golang versions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.18, 1.19]
+        go-version: [1.22, 1.23]
 
     steps:
       - uses: actions/checkout@v2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ably/ably-control-go
 
-go 1.18
+go 1.23
 
 require github.com/stretchr/testify v1.7.1
 


### PR DESCRIPTION
Using v1.23 (latest stable) & v1.22.
