### PR TITLE
Removal of batchingPolicy, add Conflation arguments

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.22, 1.23]
+        go-version: [1.22, 1.23, 1.24]
 
     steps:
       - uses: actions/checkout@v2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/ably/ably-control-go
 
-go 1.23
+go 1.24
+
+toolchain go1.24.1
 
 require github.com/stretchr/testify v1.7.1
 

--- a/namespaces.go
+++ b/namespaces.go
@@ -31,10 +31,18 @@ type Namespace struct {
 	// messages instead of sending them out immediately to subscribers as per
 	// the configured policy.
 	BatchingEnabled bool `json:"batchingEnabled"`
-	// When configured, sets the policy for message batching.
-	BatchingPolicy string `json:"batchingPolicy"`
 	// When configured, sets the maximium batching interval in the channel.
 	BatchingInterval *int `json:"batchingInterval,omitempty"`
+	// If `true`, enables conflation for channels within this namespace.
+	// Conflation reduces the number of messages sent to subscribers by
+	// combining multiple messages into a single message.
+	ConflationEnabled bool `json:"conflationEnabled"`
+	// The interval in milliseconds at which messages are conflated. This
+	// determines how frequently messages are combined into a single message.
+	ConflationInterval *int `json:"conflationInterval"`
+	// The key used to determine which messages should be conflated. Messages
+	// with the same conflation key will be combined into a single message.
+	ConflationKey string `json:"conflationKey"`
 }
 
 // Namespaces lists the namespaces for the specified application ID.
@@ -68,6 +76,6 @@ func (c *Client) DeleteNamespace(appID, namespaceID string) error {
 	return err
 }
 
-func BatchingInterval(interval int) *int {
+func Interval(interval int) *int {
 	return &interval
 }

--- a/namespaces_test.go
+++ b/namespaces_test.go
@@ -42,8 +42,39 @@ func TestNamespaces(t *testing.T) {
 		TlsOnly:          true,
 		ExposeTimeserial: true,
 		BatchingEnabled:  true,
-		BatchingPolicy:   "simple",
-		BatchingInterval: BatchingInterval(100),
+		BatchingInterval: Interval(100),
+	}
+
+	n, err = client.UpdateNamespace(app.ID, &namespace)
+	assert.NoError(t, err)
+	assert.Equal(t, namespace, n)
+
+	namespace = Namespace{
+		ID:               namespace.ID,
+		Authenticated:    true,
+		Persisted:        true,
+		PersistLast:      true,
+		PushEnabled:      true,
+		TlsOnly:          true,
+		ExposeTimeserial: true,
+		BatchingEnabled:  false,
+	}
+
+	n, err = client.UpdateNamespace(app.ID, &namespace)
+	assert.NoError(t, err)
+	assert.Equal(t, namespace, n)
+
+	namespace = Namespace{
+		ID:                 namespace.ID,
+		Authenticated:      true,
+		Persisted:          true,
+		PersistLast:        true,
+		PushEnabled:        true,
+		TlsOnly:            true,
+		ExposeTimeserial:   true,
+		ConflationEnabled:  true,
+		ConflationInterval: Interval(1000),
+		ConflationKey:      "test",
 	}
 
 	n, err = client.UpdateNamespace(app.ID, &namespace)


### PR DESCRIPTION
In the upstream Control API, we removed the `batchingPolicy` field and replaced it with `conflationEnabled`, `conflationInterval` and `conflationKey` fields[1].

This updates the Go client to match these changes.

[1] https://github.com/ably/website/pull/6669/commits/293b854cf756587cb5203723712ed6e9ec3f3a01