### PR TITLE
[INF-6633] Amend API discrepancies

### DIFF
--- a/rules.go
+++ b/rules.go
@@ -417,10 +417,6 @@ type AmqpExternalTarget struct {
 	// physical queue. See this Ably knowledge base article for details.
 	// https://knowledge.ably.com/what-is-the-format-of-the-routingkey-for-an-amqp-or-kinesis-reactor-rule
 	RoutingKey string `json:"routingKey,omitempty"`
-	// The RabbitMQ exchange, if needed supports interpolation;
-	// see https://faqs.ably.com/what-is-the-format-of-the-routingkey-for-an-amqp-or-kinesis-reactor-rule
-	// for more info. If you don't use RabbitMQ exchanges, leave this blank.
-	Exchange string `json:"exchange,omitempty"`
 	// Reject delivery of the message if the route does not exist, otherwise fail silently.
 	MandatoryRoute bool `json:"mandatoryRoute"`
 	// Marks the message as persistent, instructing the broker to write it to disk if it is in a durable queue.

--- a/rules_test.go
+++ b/rules_test.go
@@ -45,7 +45,6 @@ func TestRuleAmqpExternal(t *testing.T) {
 	target := &AmqpExternalTarget{
 		Url:                "amqps://test.com",
 		RoutingKey:         "key",
-		Exchange:           "exchange",
 		MandatoryRoute:     true,
 		PersistentMessages: true,
 		MessageTTL:         50,
@@ -234,8 +233,16 @@ func testRule(t *testing.T, target Target) {
 	assert.NoError(t, err)
 	assert.Equal(t, rule.RequestMode, r.RequestMode)
 	assert.Equal(t, rule.Source, r.Source)
-	assert.Equal(t, rule.Target, r.Target)
 	assert.Equal(t, rule.Target.TargetType(), r.Target.TargetType())
+
+	// TlsTrustCerts is write-only in the API — accepted on create but never
+	// returned. Nil it out on the sent target before comparing so the full
+	// struct equality check still works.
+	if p, ok := rule.Target.(*PulsarTarget); ok {
+		assert.Nil(t, r.Target.(*PulsarTarget).TlsTrustCerts, "API should not echo back TlsTrustCerts")
+		p.TlsTrustCerts = nil
+	}
+	assert.Equal(t, rule.Target, r.Target)
 	assert.NotEmpty(t, r.ID)
 	assert.NotEmpty(t, r.AppID)
 	assert.NotEmpty(t, r.Version)


### PR DESCRIPTION
This commit fixes some discrepancies between the client and the upstream
API by removing the Exchange field in the Amqp rule, and amending the
test for the pulsar tls certs which are not echoed back in the server
response.