### PR TITLE
Release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [1.0.0](https://github.com/ably/ably-control-go/tree/v1.0.0)
+
+**NOTICE OF DEPRECATION**
+
+This repository is deprecated and will receive no further updates after this release. The library has moved to [`ably/terraform-provider-ably`](https://github.com/ably/terraform-provider-ably), where it is now maintained alongside its primary consumer, the Ably Terraform provider. Consolidating the two reduces duplicated maintenance and lets the client track changes to the Control API more closely.
+
+The new library is **not a drop-in replacement**. Parts of it have been rewritten to better reflect the current shape of the Control API, so the public API surface differs from this one. Consumers migrating across should expect to make code changes.
+
+**BREAKING CHANGES**
+
+- ErrorInfo.Details type changed from map[string][]string to map[string]interface{} to match actual API responses
+- IngressRule.RuleType() removed (use Target.TargetType() instead)
+
+[Full Changelog](https://github.com/ably/ably-control-go/compare/v0.8.0..v1.0.0)
+
+**Merged pull requests:**
+
+- Update the client to the latest API spec [\#41](https://github.com/ably/ably-control-go/pull/41) ([martin-ably](https://github.com/martin-ably))
+
 ## [0.8.0](https://github.com/ably/ably-control-go/tree/v0.8.0)
 
 [Full Changelog](https://github.com/ably/ably-control-go/compare/v0.7.0..v0.8.0)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 
 _[Ably](https://ably.com) is the platform that powers synchronized digital experiences in realtime. Whether attending an event in a virtual venue, receiving realtime financial information, or monitoring live car performance data – consumers simply expect realtime digital experiences as standard. Ably provides a suite of APIs to build, extend, and deliver powerful digital experiences in realtime for more than 250 million devices across 80 countries each month. Organizations like Bloomberg, HubSpot, Verizon, and Hopin depend on Ably’s platform to offload the growing complexity of business-critical realtime data synchronization at global scale. For more information, see the [Ably documentation](https://ably.com/documentation)._
 
+> [!WARNING]
+> **This repository is deprecated and archived.**
+>
+> The library has moved to [`ably/terraform-provider-ably`](https://github.com/ably/terraform-provider-ably) and is no longer maintained here. The new library is not a drop-in replacement — parts have been rewritten and the public API differs.
+
 ## Overview
 
 This is a Go client library for the [Ably control API](https://ably.com/docs/control-api).

--- a/version.go
+++ b/version.go
@@ -3,4 +3,4 @@ package control
 // VERSION is the version of this package.
 //
 // It is sent in requests to the Control API in the Ably-Agent HTTP header.
-const VERSION = "0.8.0"
+const VERSION = "1.0.0"


### PR DESCRIPTION
**NOTICE OF DEPRECATION**

This repository is deprecated and will receive no further updates after this release. The library has moved to [`ably/terraform-provider-ably`](https://github.com/ably/terraform-provider-ably), where it is now maintained alongside its primary consumer, the Ably Terraform provider. Consolidating the two reduces duplicated maintenance and lets the client track changes to the Control API more closely.

The new library is **not a drop-in replacement**. Parts of it have been rewritten to better reflect the current shape of the Control API, so the public API surface differs from this one. Consumers migrating across should expect to make code changes.


**BREAKING CHANGES**

- ErrorInfo.Details type changed from map[string][]string to
  map[string]interface{} to match actual API responses
- IngressRule.RuleType() removed (use Target.TargetType() instead)